### PR TITLE
Remove @author JavaDoc, remove automatically generated file headers

### DIFF
--- a/Auth/src/main/WEBAPP/index.html
+++ b/Auth/src/main/WEBAPP/index.html
@@ -1,9 +1,4 @@
 <!DOCTYPE html>
-<!--
-To change this license header, choose License Headers in Project Properties.
-To change this template file, choose Tools | Templates
-and open the template in the editor.
--->
 <html>
     <head>
         <title>TODO supply a title</title>

--- a/Auth/src/main/java/org/eastsideprep/auth/Main.java
+++ b/Auth/src/main/java/org/eastsideprep/auth/Main.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.eastsideprep.auth;
 
 import javax.servlet.http.HttpServletRequest;
@@ -13,10 +8,6 @@ import spark.Response;
 import static spark.Spark.*;
 import spark.servlet.SparkApplication;
 
-/**
- *
- * @author gmein
- */
 public class Main implements SparkApplication {
 
 //    public static void main(String[] args) {

--- a/FusorControlServer/Old/TessWrapper.java
+++ b/FusorControlServer/Old/TessWrapper.java
@@ -14,10 +14,6 @@ import net.sourceforge.tess4j.ITessAPI.TessOcrEngineMode;
 import net.sourceforge.tess4j.TessAPI;
 import net.sourceforge.tess4j.util.ImageIOHelper;
 
-/**
- *
- * @author gmein
- */
 public class TessWrapper {
 
     public class Result {

--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/AdminContext.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/AdminContext.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.eastsideprep.fusorcontrolserver;
 
 import static com.eastsideprep.fusorcontrolserver.WebServer.cd;
@@ -14,10 +9,6 @@ import com.eastsideprep.fusorweblog.FusorWebLogState;
 import static spark.Spark.halt;
 import static spark.Spark.stop;
 
-/**
- *
- * @author gmein
- */
 public class AdminContext extends ObserverContext {
 
     AdminContext(String login, WebServer ws) {

--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/Context.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/Context.java
@@ -1,16 +1,7 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.eastsideprep.fusorcontrolserver;
 
 import com.eastsideprep.weblog.WebLogObserver;
 
-/**
- *
- * @author gmein
- */
 public class Context {
     String login;
     boolean isAdmin;

--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/ObserverContext.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/ObserverContext.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.eastsideprep.fusorcontrolserver;
 
 import static com.eastsideprep.fusorcontrolserver.WebServer.cd;
@@ -17,10 +12,6 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletResponse;
 import static spark.Spark.halt;
 
-/**
- *
- * @author gmein
- */
 public class ObserverContext extends Context {
 
     ObserverContext(String login, WebServer ws) {

--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorweblog/FusorWebLogEntry.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorweblog/FusorWebLogEntry.java
@@ -6,10 +6,6 @@ package com.eastsideprep.fusorweblog;
 
 import com.eastsideprep.weblog.WebLogEntry;
 
-/**
- *
- * @author gmein
- */
 public class FusorWebLogEntry extends WebLogEntry {
 
     public String device;

--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorweblog/FusorWebLogState.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorweblog/FusorWebLogState.java
@@ -11,10 +11,6 @@ import com.eastsideprep.weblog.WebLog;
 import com.eastsideprep.weblog.WebLogEntry;
 import com.eastsideprep.weblog.WebLogState;
 
-/**
- *
- * @author gmein
- */
 public class FusorWebLogState implements WebLogState {
 
     private WebLog log;

--- a/FusorControlServer/src/main/java/com/eastsideprep/serialdevice/Arduino.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/serialdevice/Arduino.java
@@ -1,17 +1,8 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.eastsideprep.serialdevice;
 
 import com.fazecast.jSerialComm.SerialPort;
 import com.fazecast.jSerialComm.SerialPortEvent;
 
-/**
- *
- * @author gmein
- */
 public class Arduino extends SerialDevice {
 
     Arduino(Arduino a) {

--- a/FusorControlServer/src/main/java/com/eastsideprep/serialdevice/Domino.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/serialdevice/Domino.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.eastsideprep.serialdevice;
 
 import com.eastsideprep.fusorcontrolserver.FusorControlServer;
@@ -13,10 +8,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
-/**
- *
- * @author gmein
- */
 public class Domino extends SerialDevice {
 
     Thread autoStatusThread;

--- a/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLog.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLog.java
@@ -11,10 +11,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-/**
- *
- * @author gmein
- */
 public class WebLog {
 
     private final ReadWriteLock rwl = new ReentrantReadWriteLock();

--- a/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogEntry.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogEntry.java
@@ -4,10 +4,6 @@
  */
 package com.eastsideprep.weblog;
 
-/**
- *
- * @author gmein
- */
 public abstract class WebLogEntry {
     public long time;
 }

--- a/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogObserver.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogObserver.java
@@ -6,10 +6,6 @@ package com.eastsideprep.weblog;
 
 import java.util.ArrayList;
 
-/**
- *
- * @author gmein
- */
 public class WebLogObserver {
 
     private final WebLog log;

--- a/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogState.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/weblog/WebLogState.java
@@ -6,10 +6,6 @@ package com.eastsideprep.weblog;
 
 import java.util.ArrayList;
 
-/**
- *
- * @author gmein
- */
 public interface WebLogState {
 
     WebLogState copy();


### PR DESCRIPTION
This does two things:
1. Remove all the `@author gmein` JavaDoc comments. We have `git blame` if we need to know who wrote a bit of code.
2. Remove a bunch of Netbeans-generated file headers