### PR TITLE
Fix XSS vulnerability in comment box

### DIFF
--- a/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/DataLogger.java
+++ b/FusorControlServer/src/main/java/com/eastsideprep/fusorcontrolserver/DataLogger.java
@@ -11,6 +11,7 @@ import org.json.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -136,10 +137,15 @@ public class DataLogger {
         StringBuilder sb = DataLogger.startPseudoDeviceEntry(1000);
         DataLogger.addPseudoDeviceStringVariable(sb, "observer", observer, millis);
         DataLogger.addPseudoDeviceStringVariable(sb, "ip", ip, millis);
-        DataLogger.addPseudoDeviceStringVariable(sb, "text", text, millis);
+        DataLogger.addPseudoDeviceStringVariable(sb, "text", (
+                // encode user-submitted data as Base 64 so comments containing
+                // quotes won't cause issues in the JOSN file
+                java.util.Base64.getEncoder().encodeToString(
+                    text.getBytes(StandardCharsets.UTF_8)
+                )), millis);
         return DataLogger.closePseudoDeviceEntry(sb, millis);
     }
-
+    
     static String makeEmergencyStopDeviceText(String observer, String ip, long millis) {
         StringBuilder sb = DataLogger.startPseudoDeviceEntry(1000);
         DataLogger.addPseudoDeviceStringVariable(sb, "observer", observer, millis);

--- a/FusorControlServer/src/main/resources/public/console.html
+++ b/FusorControlServer/src/main/resources/public/console.html
@@ -74,7 +74,7 @@
                 <p id="data" style="margin: 0px; overflow-y:scroll; width:100%; height:100%; white-space: nowrap; overflow-x: hidden;font-size: medium;font-family: 'Courier New', Courier, monospace;"></p>
             </div>
             <div class="fchat">
-                <p id="chat" style="margin: 0px; overflow-y:scroll; width:100%; height:100%; white-space: nowrap; overflow-x: auto;font-size:smaller;"></p>
+                <p id="chat" style="margin: 0px; overflow-y:scroll; width:100%; height:100%; white-space: nowrap; overflow-x: auto;font-size:smaller; word-break: break-all; white-space: normal;"></p>
             </div>
             <div class="fcamview" onclick="window.open('cameras.html', 'popup_window', 'width=1920,height=1040'); return false;">
                 <img id="cam1" style="width:48%;height:100%;display:none;padding:0%" src="">
@@ -96,7 +96,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.js"></script>
         <!--script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/0.6.6/chartjs-plugin-zoom.js"></script-->
         <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@0.7.5/dist/chartjs-plugin-zoom.js"></script>
-
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.1/underscore-umd-min.js"></script>
         <script type="text/javascript" src="https://canvasjs.com/assets/script/canvasjs.min.js"></script>
         <script type="text/javascript" src="js/common.js"></script>
         <script type="text/javascript" src="js/sample_data.js"></script>

--- a/FusorControlServer/src/main/resources/public/js/comment.js
+++ b/FusorControlServer/src/main/resources/public/js/comment.js
@@ -21,8 +21,13 @@ function displayComment(observer, time, text) {
     chat.innerHTML += "<span " + (observer === "DeviceManager" && !text.includes("Adding") ? "style='color:red'" : "") + ">"
             + observer + "</span>"
             //+ "(" + ip + ")," 
-            + " (" + Math.round((time - logStart) / 100) / 10 + "): "
-            + text + "<br>";
+            + " (" + Math.round((time - logStart) / 100) / 10 + "): ";
+
+    // first we Base 64 decode the comment - atop(...) does that
+    // then we use the Underscore.js library to escape any HTML to prevent XSS
+    chat.innerHTML += _.escape(atob(text));
+
+    chat.innerHTML += "<br>";
     chat.scrollTop = chat.scrollHeight;
 }
 
@@ -35,4 +40,3 @@ function printHTML(msg) {
     var chat = document.getElementById("chat");
     chat.innerHTML += msg;
 }
-


### PR DESCRIPTION
This fixes the XSS issue (and allows the `"` in comments, because this also prevents comments from causing issues in the JSON. This PR
1. Fixes XSS in the comment/log box - It uses [Underscore.js](https://underscorejs.org/) to escape the comment to prevent XSS
2. Base 64 encodes comments in the log file - this prevents people from injecting random stuff into the log file (JSON uses double-quotes to signify strings, because comments containing quotes would confuse the parser, we just base 64 encode the comment). In theory, we could escape before putting it in the JSON and a second time before displaying it as HTML, but doing both seemed confusing, so I opted to do this instead
3. Allows word-wrap [at the character level, as opposed to breaking at words] in the comment box - this prevents long comments, such as some XSS payloads) from breaking the UI